### PR TITLE
Change location of error handling logic in image representation module

### DIFF
--- a/quantum_image_processing/data_encoder/image_representations/frqi.py
+++ b/quantum_image_processing/data_encoder/image_representations/frqi.py
@@ -22,18 +22,6 @@ class FRQI(ImageEmbedding):
                 f"Input img_dims must have same dimensions."
             )
 
-        if len(pixel_vals) != math.prod(self.img_dims):
-            raise ValueError(
-                f"No. of pixel values {len(pixel_vals)} must be equal to "
-                f"the product of image dimensions {math.prod(self.img_dims)}."
-            )
-
-        for val in pixel_vals:
-            if val < 0 or val > 255:
-                raise ValueError(
-                    "Pixel values cannot be less than 0 or greater than 255."
-                )
-
         # feature_dim = no. of qubits for pixel position embedding
         self.feature_dim = int(np.sqrt(math.prod(self.img_dims)))
 

--- a/quantum_image_processing/data_encoder/image_representations/image_embedding.py
+++ b/quantum_image_processing/data_encoder/image_representations/image_embedding.py
@@ -1,6 +1,7 @@
 """Abstract Base Class for Image Embedding"""
 from __future__ import annotations
 from abc import ABC, abstractmethod
+import math
 
 
 class ImageEmbedding(ABC):
@@ -19,6 +20,18 @@ class ImageEmbedding(ABC):
 
         if not isinstance(pixel_vals, list):
             raise TypeError("Input pixel_vals must be of the type list.")
+
+        if len(pixel_vals) != math.prod(img_dims):
+            raise ValueError(
+                f"No. of pixel values {len(pixel_vals)} must be equal to "
+                f"the product of image dimensions {math.prod(img_dims)}."
+            )
+
+        for val in pixel_vals:
+            if val < 0 or val > 255:
+                raise ValueError(
+                    "Pixel values cannot be less than 0 or greater than 255."
+                )
 
         self.img_dims = img_dims
         self.pixel_vals = pixel_vals

--- a/tests/data_encoder/image_representations/test_frqi.py
+++ b/tests/data_encoder/image_representations/test_frqi.py
@@ -66,7 +66,7 @@ class TestFRQI:
         with raises(TypeError, match=r"Input pixel_vals must be of the type list."):
             _ = FRQI(img_dims, pixel_vals)
 
-    @pytest.mark.parametrize("img_dims, pixel_vals", [((2, 3), [range(6)])])
+    @pytest.mark.parametrize("img_dims, pixel_vals", [((2, 3), list(range(6)))])
     def test_init_square_images(self, img_dims, pixel_vals):
         """Tests if the input img_dims represents a square image."""
         with raises(


### PR DESCRIPTION
Change the location of error handling logic that checks the `pixel_values` from `FRQI` class to `ImageEmbedding` base class.
This change was required while building the INEQR class that requires error checks on `pixel_vals`. This will be covered in an upcoming PR.