### PR TITLE
Change fail-fast to true

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 


### PR DESCRIPTION
The builds continue to run after failing some steps. Considering that the size of the library is small, `fail-fast = false` is unnecessary. It needlessly increases the time to get feedback on the builds. 

This can be changed when the library is substantially large.