### PR TITLE
Use `twine` to deploy to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,7 +10,7 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
 
     strategy:
       matrix:


### PR DESCRIPTION
Using `twine` to deploy to pypi. The automation fails to work without twine; python upload fails with an error about API keys.