### PR TITLE
Change `colored` argument to include number of color channels.

### DIFF
--- a/piqture/data_encoder/image_representations/frqi.py
+++ b/piqture/data_encoder/image_representations/frqi.py
@@ -26,7 +26,7 @@ class FRQI(ImageEmbedding, ImageMixin):
     """
 
     def __init__(self, img_dims: tuple[int, int], pixel_vals: list[list]):
-        ImageEmbedding.__init__(self, img_dims, pixel_vals, colored=False)
+        ImageEmbedding.__init__(self, img_dims, pixel_vals)
 
         # feature_dim = no. of qubits for pixel position embedding
         self.feature_dim = int(np.sqrt(math.prod(self.img_dims)))

--- a/piqture/data_encoder/image_representations/image_embedding.py
+++ b/piqture/data_encoder/image_representations/image_embedding.py
@@ -22,6 +22,8 @@ class ImageEmbedding(ABC):
     on a quantum circuit. It consists of two components:
     - Pixel position embedding
     - Pixel value (color) embedding
+    - Color channels to indice how many color channels can be represented.
+        By default, grayscale = 1 color channel, and RGB = 3
     """
 
     def __init__(

--- a/piqture/data_encoder/image_representations/neqr.py
+++ b/piqture/data_encoder/image_representations/neqr.py
@@ -29,7 +29,7 @@ class NEQR(ImageEmbedding, ImageMixin):
         pixel_vals: list[list],
         max_color_intensity: int = 255,
     ):
-        ImageEmbedding.__init__(self, img_dims, pixel_vals, colored=False)
+        ImageEmbedding.__init__(self, img_dims, pixel_vals)
 
         if max_color_intensity < 0 or max_color_intensity > 255:
             raise ValueError(


### PR DESCRIPTION
Simply mentioning whether the QIR method supports `colored` images (`boolean`) is not satisfactory. More information is required in cases where RGB channels exist with other transparency, watermark, or alpha channels. 

Different number of color channels also affects the number of lists in a `pixel_vals` argument. For example, for MCRQI, `pixel_vals: list[list]` there must be a maximum of 4 lists representing RGB-alpha channels each. Meanwhile, for other colored QIR techniques, there might only be 3 channels - RGB.