### PR TITLE
Remove linting by flake8 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,13 +32,13 @@ jobs:
         python -m pip install flake8 pytest pytest-cov pylint coveralls
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-    - name: Lint with pylint, flake8
+    - name: Lint with pylint
       run: |
         pylint $(git ls-files '*.py')
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Test with pytest
       run: |


### PR DESCRIPTION
Using `flake8` with `pylint` is somewhat redundant. 
It is also currently creating linting errors with sphinx. Refer #92 