### PR TITLE
added implementation for brqi

### DIFF
--- a/demos/brqi.md
+++ b/demos/brqi.md
@@ -1,0 +1,97 @@
+
+# BRQI Demo
+
+This demo showcases the Bitplane Representation of Quantum Images (BRQI) using the piQture library. It demonstrates how to load an image, convert it to a quantum circuit using BRQI encoding, and visualize the results.
+
+## Prerequisites
+
+- Python 3.7+
+- piQture library
+- Qiskit
+- NumPy
+- Pillow (PIL)
+- Matplotlib
+
+## Installation
+
+1. Install the required libraries:
+
+```
+pip install piqture qiskit qiskit-aer numpy pillow matplotlib
+```
+
+2. Clone the piQture repository or ensure you have the BRQI module available.
+
+## Usage
+
+1. Place your input image in a known location.
+
+2. Update the `image_path` variable in the `main()` function:
+
+
+```
+def main():
+    # Path to your input image
+    image_path = '/Users/dylanmoraes/Downloads/image-1.png'
+```
+
+
+3. Run the script:
+
+```
+python brqi_demo.py
+```
+
+## How it works
+
+The demo follows these steps:
+
+1. **Load and preprocess the image**:
+   - Opens the image file
+   - Converts it to grayscale
+   - Resizes it to a small dimension (default 4x4)
+   - Normalizes pixel values to the range [0, 255]
+
+2. **Create BRQI circuit**:
+   - Initializes a BRQI object with the image dimensions and pixel values
+   - Generates the quantum circuit representation of the image
+
+3. **Visualize results**:
+   - Displays the original image
+   - Simulates the quantum circuit using Qiskit's QASM simulator
+   - Plots a histogram of the measurement results
+
+## Customization
+
+- To change the target size of the image, modify the `target_size` parameter in the `load_and_preprocess_image()` function call:
+
+
+```67:67:demos/brqi_demo.py
+    img_array = load_and_preprocess_image(image_path)
+```
+
+
+- To adjust the number of shots in the quantum simulation, change the `shots` parameter in the `backend.run()` function:
+
+
+```
+    job = backend.run(transpiled_circuit, shots=1000)
+```
+
+
+## Understanding the Output
+
+The script will display two plots:
+1. The original grayscale image
+2. A histogram of the measurement results from the quantum circuit simulation
+
+The histogram represents the probability distribution of different quantum states, which encodes the information from the original image in the BRQI format.
+
+## Troubleshooting
+
+If you encounter any issues:
+- Ensure all required libraries are installed correctly
+- Check that the image path is correct and the file exists
+- Verify that the piQture library and BRQI module are properly imported
+
+For more information on the BRQI encoding method and the piQture library, refer to the main piQture documentation.

--- a/demos/brqi_demo.py
+++ b/demos/brqi_demo.py
@@ -1,0 +1,76 @@
+import numpy as np
+from PIL import Image
+from qiskit import QuantumCircuit, transpile
+from qiskit_aer import Aer
+from qiskit.visualization import plot_histogram
+import matplotlib.pyplot as plt
+
+from piqture.embeddings.image_embeddings.brqi import BRQI
+
+def load_and_preprocess_image(image_path, target_size=(4, 4)):
+    # Load the image
+    img = Image.open(image_path)
+    
+    # Convert to grayscale
+    img = img.convert('L')
+    
+    # Resize the image
+    img = img.resize(target_size)
+    
+    # Convert to numpy array
+    img_array = np.array(img)
+    
+    # Normalize pixel values to range [0, 255]
+    img_array = (img_array / img_array.max() * 255).astype(int)
+    
+    return img_array
+
+def create_brqi_circuit(img_array):
+    img_dims = img_array.shape
+    pixel_vals = [img_array.flatten().tolist()]
+    
+    # Create BRQI object
+    brqi_object = BRQI(img_dims, pixel_vals)
+    
+    # Generate BRQI circuit
+    brqi_circuit = brqi_object.brqi()
+    
+    return brqi_circuit
+
+def visualize_results(original_image, brqi_circuit):
+    # Display original image
+    plt.figure(figsize=(10, 5))
+    plt.subplot(1, 2, 1)
+    plt.imshow(original_image, cmap='gray')
+    plt.title('Original Image')
+    
+    # Simulate the quantum circuit
+    backend = Aer.get_backend('qasm_simulator')
+    transpiled_circuit = transpile(brqi_circuit, backend)
+    job = backend.run(transpiled_circuit, shots=1000)
+    result = job.result()
+    counts = result.get_counts()
+    
+    # Plot the histogram of measurement results
+    plt.subplot(1, 2, 2)
+    plot_histogram(counts)
+    plt.title('BRQI Measurement Results')
+    
+    plt.tight_layout()
+    plt.show()
+
+def main():
+    # Path to your input image
+    image_path = '/path/to/image.jpg'
+    
+    # Load and preprocess the image
+    img_array = load_and_preprocess_image(image_path)
+    
+    # Create BRQI circuit
+    brqi_circuit = create_brqi_circuit(img_array)
+    
+    # Visualize results
+    visualize_results(img_array, brqi_circuit)
+
+if __name__ == "__main__":
+    main()

--- a/piqture/embeddings/image_embeddings/__init__.py
+++ b/piqture/embeddings/image_embeddings/__init__.py
@@ -16,10 +16,12 @@ from .frqi import FRQI
 from .ineqr import INEQR
 from .mcrqi import MCRQI
 from .neqr import NEQR
+from .brqi import BRQI
 
 __all__ = [
     "FRQI",
     "NEQR",
     "INEQR",
     "MCRQI",
+    "BRQI",
 ]

--- a/piqture/embeddings/image_embeddings/brqi.py
+++ b/piqture/embeddings/image_embeddings/brqi.py
@@ -1,0 +1,90 @@
+
+"""Bitplane Representation of Quantum Images (BRQI)"""
+
+from __future__ import annotations
+
+import math
+from typing import Union
+import numpy as np
+from qiskit.circuit import QuantumCircuit
+
+from piqture.embeddings.image_embedding import ImageEmbedding
+from piqture.mixin.image_embedding_mixin import ImageMixin
+
+class BRQI(ImageEmbedding, ImageMixin):
+    """Represents images in BRQI representation format."""
+
+    def __init__(
+        self,
+        img_dims: tuple[int, int],
+        pixel_vals: Union[list[list], np.ndarray],
+        max_color_intensity: int = 255,
+    ):
+        self.max_color_intensity = max_color_intensity
+        self.validate_max_color_intensity()
+        
+        # Convert numpy array to list if necessary
+        if isinstance(pixel_vals, np.ndarray):
+            pixel_vals = [pixel_vals.flatten().tolist()]
+        
+        ImageEmbedding.__init__(self, img_dims, pixel_vals)
+        self.color_qubits = int(np.ceil(np.log2(self.max_color_intensity + 1)))
+        self.feature_dim = int(np.ceil(np.log2(math.prod(self.img_dims))))
+        
+        # Initialize the _circuit attribute
+        self._circuit = QuantumCircuit(self.feature_dim + self.color_qubits)
+
+    def validate_max_color_intensity(self):
+        if self.max_color_intensity < 0 or self.max_color_intensity > 255:
+            raise ValueError(
+                "Maximum color intensity cannot be less than 0 or greater than 255."
+            )
+
+    def validate_number_pixel_lists(self, pixel_vals):
+        if len(pixel_vals) > 1:
+            raise ValueError(
+                f"{self.__class__.__name__} supports grayscale images only. "
+                f"No. of pixel_lists in pixel_vals must be maximum 1."
+            )
+
+    @property
+    def circuit(self):
+        """Returns BRQI circuit."""
+        return self._circuit
+
+    def pixel_position(self, pixel_pos_binary: str):
+        """Embeds pixel position values in a circuit."""
+        ImageMixin.pixel_position(self.circuit, pixel_pos_binary)
+
+    def pixel_value(self, *args, **kwargs):
+        """Embeds pixel (color) values in a circuit"""
+        color_byte = kwargs.get("color_byte")
+        control_qubits = list(range(self.feature_dim))
+        for index, color in enumerate(color_byte):
+            if color == "1":
+                self.circuit.mcx(
+                    control_qubits=control_qubits,
+                    target_qubit=self.feature_dim + index
+                )
+
+    def brqi(self) -> QuantumCircuit:
+        """
+        Builds the BRQI image representation on a circuit.
+
+        Returns:
+            QuantumCircuit: final circuit with the BRQI image
+            representation.
+        """
+        self.pixel_vals = np.array(self.pixel_vals).flatten()
+        for i in range(self.feature_dim):
+            self.circuit.h(i)
+
+        num_pixels = math.prod(self.img_dims)
+        for pixel in range(num_pixels):
+            color_byte = f"{int(self.pixel_vals[pixel]):0>{self.color_qubits}b}"
+            self.pixel_value(color_byte=color_byte)
+
+        # Add measurement to all qubits
+        self.circuit.measure_all()
+
+        return self.circuit

--- a/tests/embeddings/image_embeddings/test_brqi.py
+++ b/tests/embeddings/image_embeddings/test_brqi.py
@@ -1,0 +1,149 @@
+
+"""Unit test for BRQI class"""
+
+from __future__ import annotations
+
+import math
+from unittest import mock
+
+import numpy as np
+import pytest
+from pytest import raises
+from qiskit.circuit import QuantumCircuit
+
+import sys
+import os
+
+# Add the project root to the Python path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+sys.path.insert(0, project_root)
+print(f"Updated Python path: {sys.path}")
+
+# Now try to import BRQI
+try:
+    from piqture.embeddings.image_embeddings.brqi import BRQI
+    print("Successfully imported BRQI")
+except ImportError as e:
+    print(f"Error importing BRQI: {e}")
+from piqture.embeddings.image_embeddings.brqi import BRQI
+
+
+MAX_COLOR_INTENSITY = 255
+
+
+@pytest.fixture(name="brqi_pixel_value")
+def brqi_pixel_value_fixture():
+    """Fixture for embedding pixel values."""
+
+    def _circuit(img_dims, pixel_val, color_qubits):
+        feature_dim = int(np.ceil(np.log2(math.prod(img_dims))))
+        pixel_val_bin = f"{int(pixel_val):0>{color_qubits}b}"
+        test_circuit = QuantumCircuit(feature_dim + color_qubits)
+
+        # Add gates to test_circuit
+        for index, color in enumerate(pixel_val_bin):
+            if color == "1":
+                test_circuit.mcx(list(range(feature_dim)), feature_dim + index)
+        return test_circuit
+
+    return _circuit
+
+
+class TestBRQI:
+    """Tests for BRQI image representation class"""
+
+    @pytest.mark.parametrize(
+        "img_dims, pixel_vals, max_color_intensity",
+        [
+            ((2, 2), [list(range(251, 255))], 300),
+            ((2, 2), [list(range(251, 255))], -20),
+        ],
+    )
+    def test_max_color_intensity(self, img_dims, pixel_vals, max_color_intensity):
+        """Tests value of maximum color intensity."""
+        with raises(
+            ValueError,
+            match=r"Maximum color intensity cannot be less than \d or greater than \d.",
+        ):
+            _ = BRQI(img_dims, pixel_vals, max_color_intensity)
+
+    @pytest.mark.parametrize(
+        "img_dims, pixel_vals, max_color_intensity",
+        [((2, 2), [list(range(251, 255))], MAX_COLOR_INTENSITY)],
+    )
+    def test_circuit_property(self, img_dims, pixel_vals, max_color_intensity):
+        """Tests the BRQI circuits initialization."""
+        feature_dim = int(np.ceil(np.log2(math.prod(img_dims))))
+        color_qubits = int(np.ceil(np.log2(max_color_intensity + 1)))
+        test_circuit = QuantumCircuit(feature_dim + color_qubits)
+        assert BRQI(img_dims, pixel_vals).circuit == test_circuit
+
+    @pytest.mark.parametrize(
+        "img_dims, pixel_vals, max_color_intensity",
+        [((2, 2), [list(range(235, 239))], MAX_COLOR_INTENSITY)],
+    )
+    def test_pixel_value(
+        self, img_dims, pixel_vals, max_color_intensity, brqi_pixel_value
+    ):
+        """Tests the circuit received after pixel value embedding."""
+        brqi_object = BRQI(img_dims, pixel_vals, max_color_intensity)
+        color_qubits = int(np.ceil(np.log2(max_color_intensity + 1)))
+        feature_dim = int(np.ceil(np.log2(math.prod(img_dims))))
+        mock_circuit = QuantumCircuit(feature_dim + color_qubits)
+
+        for _, pixel_val in enumerate(pixel_vals[0]):
+            mock_circuit.clear()
+            test_circuit = brqi_pixel_value(img_dims, pixel_val, color_qubits)
+
+            with mock.patch(
+                "piqture.embeddings.image_embeddings.brqi.BRQI.circuit",
+                new_callable=lambda: mock_circuit,
+            ):
+                brqi_object.pixel_value(color_byte=f"{pixel_val:0>{color_qubits}b}")
+                assert mock_circuit == test_circuit
+
+    @pytest.mark.parametrize(
+        "img_dims, pixel_vals, max_color_intensity",
+        [((2, 2), [list(range(1, 5))], MAX_COLOR_INTENSITY)],
+    )
+    def test_brqi(
+        self,
+        img_dims,
+        pixel_vals,
+        max_color_intensity,
+        brqi_pixel_value,
+    ):
+        """Tests the final BRQI circuit."""
+        brqi_object = BRQI(img_dims, pixel_vals, max_color_intensity)
+        color_qubits = int(np.ceil(np.log2(max_color_intensity + 1)))
+        feature_dim = int(np.ceil(np.log2(math.prod(img_dims))))
+        mock_circuit = QuantumCircuit(feature_dim + color_qubits)
+
+        test_circuit = QuantumCircuit(feature_dim + color_qubits)
+        test_circuit.h(list(range(feature_dim)))
+        for index, pixel_val in enumerate(pixel_vals[0]):
+            pixel_pos_binary = f"{index:0>{feature_dim}b}"
+            mock_circuit.clear()
+            test_circuit.compose(
+                brqi_pixel_value(img_dims, pixel_val, color_qubits), inplace=True
+            )
+
+        with mock.patch(
+            "piqture.embeddings.image_embeddings.brqi.BRQI.circuit",
+            new_callable=lambda: mock_circuit,
+        ):
+            brqi_object.brqi()
+            assert mock_circuit == test_circuit
+
+    @pytest.mark.parametrize(
+        "img_dims, pixel_vals, max_color_intensity",
+        [((2, 2), np.array([[1, 2], [3, 4]]), MAX_COLOR_INTENSITY)],
+    )
+    def test_brqi_with_numpy_array(self, img_dims, pixel_vals, max_color_intensity):
+        """Tests BRQI with NumPy array input."""
+        brqi_object = BRQI(img_dims, pixel_vals, max_color_intensity)
+        circuit = brqi_object.brqi()
+        
+        # Check if the circuit is generated correctly
+        assert isinstance(circuit, QuantumCircuit)
+        assert circuit.num_qubits == int(np.ceil(np.log2(math.prod(img_dims)))) + int(np.ceil(np.log2(max_color_intensity + 1)))


### PR DESCRIPTION
## Added implementation for Bitplane Representation of Quantum Images (BRQI)  #131 

- The implementation of BRQI is present within the embeddings/image_embeddings/brqi.py file.
- Added test cases for the BRQI Module in the tests/embeddings/image_embeddings/test_brqi.py file
- Added a demo on how to use this module in demos/brqi_demo.py along with a step by step explanation present in the demos/brqi.md file.
