### PR TITLE
Adding image size in data loader in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ from piqture.data_loader.mnist_data_loader import load_mnist_dataset
 from piqture.embeddings.image_embeddings.ineqr import INEQR
 
 # Load MNIST dataset
-train_dataset, test_dataset = load_mnist_dataset()
+train_dataset, test_dataset = load_mnist_dataset(img_size=(8, 8))
 
 # Retrieve a single image from the dataset
 image, label = train_dataset[0]


### PR DESCRIPTION
#Resolves #150

This issue resolves the value error pointed out in Issue 150. 
The Data loader loads images that are not in the powers of 2, which is a requirement for the image processing to work. So a parameter needs to be passed in the data loader.